### PR TITLE
Fix file encoding warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <version>1.0.0</version>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>


### PR DESCRIPTION
This prevents Maven from outputting the following warning when trying to compile:
```
[WARNING] File encoding has not been set, using platform encoding UTF-8. Build is platform dependent!
[WARNING] See https://maven.apache.org/general.html#encoding-warning
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```