### PR TITLE
Fix NullPointerException: Cannot invoke "com.viaversion.viaversion.api.protocol.version.Protocol Version. equals(Object)" because "serverVersion" is null

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build via Maven
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4.2.2
+
+    - name: Set up JDK
+      uses: actions/setup-java@v4.7.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'maven'
+
+    - name: Build with Maven
+      run: mvn package -B --file pom.xml
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: ViaLimbo
+        path: target/ViaLimbo-*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>net.raphimc</groupId>
             <artifactId>ViaProxy</artifactId>
-            <version>3.4.3</version>
+            <version>3.4.4</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: ViaLimbo
 main: com.loohp.vialimbo.ViaLimbo
-version: 1.0.0
+version: 1.1.2
 author: LOOHP


### PR DESCRIPTION
ViaProxy has been updated to `3.4.4`, which fixes the following error:
```
NullPointerException: Cannot invoke
"com.viaversion.viaversion.api.protocol.version.Protocol Version. equals(Object)" because "serverVersion" is null
```

I've also bumped the version in `plugin.yml` to `1.1.2` (which should probably be bumped to `1.1.3` if this PR gets accepted) and added a Github Workflow to auto compile the plugin using Github Actions.

For those who wish to download the already patched version, you can find it [here](https://github.com/Avenian-Network/ViaLimbo).