### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.loohp</groupId>
     <artifactId>ViaLimbo</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -116,13 +116,13 @@
         <dependency>
             <groupId>com.loohp</groupId>
             <artifactId>Limbo</artifactId>
-            <version>0.7.14-ALPHA</version>
+            <version>0.7.16-ALPHA</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.raphimc</groupId>
             <artifactId>ViaProxy</artifactId>
-            <version>3.4.3</version>
+            <version>3.4.4</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Before this update, ViaLimbo simply did not work on Limbo versions 0.7.15-ALPHA and above: players could not enter Limbo. A small update to pom.xml fixes this.