### PR TITLE
Initialize ProxyConnection.serverVersion in ViaLimbo to prevent early nulls & bump ViaProxy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>net.raphimc</groupId>
             <artifactId>ViaProxy</artifactId>
-            <version>3.4.5</version>
+            <version>3.4.6</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/loohp/vialimbo/ViaLimbo.java
+++ b/src/main/java/com/loohp/vialimbo/ViaLimbo.java
@@ -175,6 +175,28 @@ public class ViaLimbo extends LimboPlugin implements Listener {
             io.netty.channel.Channel channel = event.getChannel();
             if (initializedChannels.add(channel)) {
                 ProxyConnection proxyConnection = ProxyConnection.fromChannel(channel);
+
+                try {
+                    if (proxyConnection.getServerVersion() == null) {
+                        Field serverVersionField = null;
+                        Class<?> cls = proxyConnection.getClass();
+                        while (cls != null) {
+                            try {
+                                serverVersionField = cls.getDeclaredField("serverVersion");
+                                break;
+                            } catch (NoSuchFieldException ignored) {
+                                cls = cls.getSuperclass();
+                            }
+                        }
+                        if (serverVersionField != null) {
+                            serverVersionField.setAccessible(true);
+                            serverVersionField.set(proxyConnection, ProtocolTranslator.AUTO_DETECT_PROTOCOL);
+                        }
+                    }
+                } catch (Exception e) {
+                    Limbo.getInstance().getConsole().sendMessage("[ViaLimbo] Warning: failed to set default serverVersion for ProxyConnection: " + e.getMessage());
+                }
+
                 SocketAddress socketAddress = proxyConnection.getC2P().remoteAddress();
                 ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
                 DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);


### PR DESCRIPTION
Prevents a NullPointerException on join caused by ViaVersion receiving a null server ProtocolVersion from ViaProxy when ViaLimbo triggers provider queries earlier than expected.
Also bumbed ViaProxy version to the latest one.